### PR TITLE
Fix apk papercuts

### DIFF
--- a/scripts/run-mobile.sh
+++ b/scripts/run-mobile.sh
@@ -7,5 +7,6 @@
 # Values used here are based on comparing with a Samsung Galaxy A13.
 export KIVY_METRICS_DENSITY=1
 export KIVY_METRICS_FONTSCALE=1
+export NETWORKPUZZLES_DEVICE_TYPE="mobile"
 # export KIVY_DPI=640
 scripts/run-desktop.sh $@ --size 952x448  # 1148x540

--- a/src/network_puzzles/device.py
+++ b/src/network_puzzles/device.py
@@ -88,7 +88,6 @@ class Device:
         if loc:
             location = loc.split(",")
             location = (int(location[0]), int(location[1]))
-            logging.debug(f"GUI: {self.hostname} {location=}")
             return location
         raise ValueError(f"Invalid JSON location data for '{self.hostname}'")
 

--- a/src/network_puzzles/gui/__init__.py
+++ b/src/network_puzzles/gui/__init__.py
@@ -292,6 +292,10 @@ class NetworkPuzzlesApp(App):
         self.title = self.app_title
         # Remove any remaining child widgets from puzzle layout.
         self.root.ids.layout.clear_widgets()
+        logging.debug(f"GUI: display: window size: {Window.size}")
+        # logging.debug(f"GUI: puzzle layout width: {self.root.ids.layout.width}")
+        logging.debug(f"GUI: display: layout height: {self.root.ids.layout.height}")
+        logging.debug(f"GUI: display: terminal height: {self.root.ids.terminal.height}")
         # Redraw the "+" button for adding new items.
         self.root.ids.layout.add_items_menu_button()
 

--- a/src/network_puzzles/gui/__init__.py
+++ b/src/network_puzzles/gui/__init__.py
@@ -271,6 +271,10 @@ class NetworkPuzzlesApp(App):
         if not self.ui.puzzle:
             Clock.schedule_once(self.on_puzzle_chooser)
 
+    def on_touch_down(self, touch):
+        logging.debug(f"GUI: touch registered at: {touch.pos}")
+        super().on_touch_down(touch)
+
     def on_undo(self):
         self.ui.undo()
 

--- a/src/network_puzzles/gui/__init__.py
+++ b/src/network_puzzles/gui/__init__.py
@@ -560,43 +560,16 @@ class NetworkPuzzlesApp(App):
 
 
 class TerminalLabel(TextInput):
-    # def on_touch_down(self, touch):
-    #     if self.collide_point(*touch.pos):
-    #         # NOTE: On mobile (touchscreen device) when TextInput is readonly
-    #         # touch.grab_current fails in super().on_touch_down(touch) because
-    #         # readonly attrib forces self.is_focusable = False during
-    #         # FocusBehavior.on_touch_down(touch):
-    #         # Ref: https://github.com/kivy/kivy/blob/8d6ce56d6233b40f74608b33f4dc7ded14869d1d/kivy/uix/behaviors/focus.py#L464C1-L472C63
-    #         # class FocusBehavior:
-    #         # [...]
-    #         #     def on_touch_down(self, touch):
-    #         #         if not self.collide_point(*touch.pos):
-    #         #             return
-    #         #         if (not self.disabled and self.is_focusable and
-    #         #             ('button' not in touch.profile or
-    #         #                 not touch.button.startswith('scroll'))):
-    #         #             self.focus = True
-    #         #             FocusBehavior.ignored_touch.append(touch)
-    #         #         return super(FocusBehavior, self).on_touch_down(touch)
-    #         # Workaround: preempt FocusBehavior.on_touch_down.
-    #         if "button" not in touch.profile:
-    #             logging.debug("App: Overriding FocusBehvaior.on_touch_down(touch)")
-    #             self.focus = True
-    #             FocusBehavior.ignored_touch.append(touch)
-    #             # result = super(FocusBehavior, self).on_touch_down(touch) # no need to propagate touch
-    #             # logging.debug(f"App: super(FocusBehavior) {result=}")
-    #             logging.debug("App: Post-override:")
-    #             for attrib in sorted(self.__dir__()):
-    #                 if not attrib.startswith("__"):
-    #                     logging.debug(f"App:  {attrib} = {getattr(self, attrib)}")
-    #             return True
-    #         else:
-    #             return super().on_touch_down(touch)
+    def on_touch_down(self, touch):
+        if not self.collide_point(*touch.pos):  # touch outside of Terminal
+            # Cancel any text selection.
+            self.cancel_selection()
+        return super().on_touch_down(touch)
 
     def on_touch_up(self, touch):
-        # REF: https://kivy.org/doc/master/guide/inputs.html#grabbing-touch-events
         # Open popup on right-click within the Terminal area (only works on
         # desktop devices, where touch.button is not None).
+        # REF: https://kivy.org/doc/master/guide/inputs.html#grabbing-touch-events
         if touch.button == "right" and touch.grab_current is self:
             touch.ungrab(self)
             CommandPopup().open()

--- a/src/network_puzzles/gui/__init__.py
+++ b/src/network_puzzles/gui/__init__.py
@@ -583,12 +583,12 @@ class TerminalLabel(TextInput):
                 logging.debug("App: Overriding FocusBehvaior.on_touch_down(touch)")
                 self.focus = True
                 FocusBehavior.ignored_touch.append(touch)
-                super(FocusBehavior, self).on_touch_down(touch)
+                result = super(FocusBehavior, self).on_touch_down(touch)
                 logging.debug("App: Post-override:")
                 for attrib in sorted(self.__dir__()):
                     if not attrib.startswith("__"):
                         logging.debug(f"App:  {attrib} = {getattr(self, attrib)}")
-                return True
+                return result
             else:
                 return super().on_touch_down(touch)
 

--- a/src/network_puzzles/gui/__init__.py
+++ b/src/network_puzzles/gui/__init__.py
@@ -585,7 +585,7 @@ class TerminalLabel(TextInput):
                 FocusBehavior.ignored_touch.append(touch)
                 super(FocusBehavior, self).on_touch_down(touch)
                 logging.debug("App: Post-override:")
-                for attrib in self.__dir__():
+                for attrib in sorted(self.__dir__()):
                     if not attrib.startswith("__"):
                         logging.debug(f"App:  {attrib} = {getattr(self, attrib)}")
                 return True

--- a/src/network_puzzles/gui/__init__.py
+++ b/src/network_puzzles/gui/__init__.py
@@ -564,6 +564,10 @@ class TerminalLabel(TextInput):
         if not self.collide_point(*touch.pos):  # touch outside of Terminal
             # Cancel any text selection.
             self.cancel_selection()
+            # Hide the Cut/Copy/Paste bubble.
+            self._hide_cut_copy_paste()
+            # Hide the selection handles.
+            self._hide_handles()
         return super().on_touch_down(touch)
 
     def on_touch_up(self, touch):

--- a/src/network_puzzles/gui/__init__.py
+++ b/src/network_puzzles/gui/__init__.py
@@ -585,9 +585,9 @@ class TerminalLabel(TextInput):
                 FocusBehavior.ignored_touch.append(touch)
                 super(FocusBehavior, self).on_touch_down(touch)
                 logging.debug("App: Post-override:")
-                for k, v in self.__dir__().items():
-                    if not k.startswith("__"):
-                        logging.debug(f"App:  {k} = {v}")
+                for attrib in self.__dir__():
+                    if not attrib.startswith("__"):
+                        logging.debug(f"App:  {attrib} = {getattr(self, attrib)}")
                 return True
             else:
                 return super().on_touch_down(touch)

--- a/src/network_puzzles/gui/__init__.py
+++ b/src/network_puzzles/gui/__init__.py
@@ -561,6 +561,11 @@ class NetworkPuzzlesApp(App):
 class TerminalLabel(TextInput):
     def on_touch_down(self, touch):
         logging.debug(f"App: touch down at: {touch.pos}; {touch.__dict__}")
+        logging.debug(f"App: {self.use_handles=}")
+        logging.debug(f"App: {self.__class__.__name__=}")
+        for a in sorted(self.__dir__()):
+            if hasattr(self, a) and not a.startswith("_"):
+                logging.debug(f"App:  {a} = {getattr(self, a)}")
         return super().on_touch_down(touch)
 
     def on_touch_up(self, touch):
@@ -572,7 +577,7 @@ class TerminalLabel(TextInput):
             touch.ungrab(self)
             CommandPopup().open()
             return True
-        return super().on_touch_down(touch)
+        return super().on_touch_up(touch)
 
 
 class AppExceptionHandler(ExceptionHandler):

--- a/src/network_puzzles/gui/__init__.py
+++ b/src/network_puzzles/gui/__init__.py
@@ -567,25 +567,17 @@ class TerminalLabel(TextInput):
             # grab status and re-grab if needed.
             super().on_touch_down(touch)
             if touch.button is None and touch.grab_current is not self:
+                logging.debug(f"App: {touch.grab_current=}")
                 touch.grab(self)
+                logging.debug(f"App: (after grab) {touch.grab_current=}")
             return True
 
     def on_touch_move(self, touch):
-        logging.debug(f"App: {self.__class__.__name__=}")
-        for a in sorted(self.__dir__()):
-            if hasattr(self, a) and not a.startswith("__"):
-                logging.debug(f"App:  {a} = {getattr(self, a)}")
-        logging.debug(f"App: {touch.__class__.__name__=}")
-        for a in sorted(touch.__dir__()):
-            if hasattr(touch, a) and not a.startswith("__"):
-                logging.debug(f"App: {a} = {getattr(touch, a)}")
-
+        logging.debug(f"App: {touch.grab_list=}")
+        logging.debug(f"App: {touch.grab_current=}")
         ret = super().on_touch_move(touch)
-
-        logging.debug(f"App: {touch.__class__.__name__=}")
-        for a in sorted(touch.__dir__()):
-            if hasattr(touch, a) and not a.startswith("__"):
-                logging.debug(f"App: {a} = {getattr(touch, a)}")
+        logging.debug(f"App: (after super) {touch.grab_list=}")
+        logging.debug(f"App: (after super) {touch.grab_current=}")
         if ret:
             return ret
 

--- a/src/network_puzzles/gui/__init__.py
+++ b/src/network_puzzles/gui/__init__.py
@@ -162,6 +162,9 @@ class NetworkPuzzlesApp(App):
     def add_terminal_line(self, line):
         if not line.endswith("\n"):
             line += "\n"
+        logging.debug(
+            f"GUI: scroll_from_swipe: {self.root.ids.terminal.scroll_from_swipe}"
+        )
         self.root.ids.terminal.text += f"{line}"
 
     def draw_devices(self, *args):
@@ -552,15 +555,6 @@ class NetworkPuzzlesApp(App):
 
 
 class TerminalLabel(TextInput):
-    def get_max_row(self, text):
-        max_row = 0
-        max_length = 0
-        for i, line in enumerate(text.split("\n")):
-            if len(line) > max_length:
-                max_row = i
-                max_length = len(line)
-        return max_row
-
     def on_touch_up(self, touch):
         # REF: https://kivy.org/doc/master/guide/inputs.html#grabbing-touch-events
         # Open popup on right-click within the Terminal area (only works on

--- a/src/network_puzzles/gui/__init__.py
+++ b/src/network_puzzles/gui/__init__.py
@@ -6,12 +6,12 @@ root_logger = logging.getLogger()
 for handler in root_logger.handlers:
     root_logger.removeHandler(handler)
 
+from kivy.config import Config
+
 from .. import session
 
 if session.device_type == "desktop":
     # Disable right-click red dot.
-    from kivy.config import Config
-
     Config.set("input", "mouse", "mouse,disable_multitouch")
 
 # Continue with remaining imports.
@@ -82,7 +82,6 @@ class NetworkPuzzlesApp(App):
             self.packet_tick_delay = 0.04  # packet pos refresh rate in seconds
             self.packet_progress_rate = 6  # % of link traveled each tick
         logging.debug(f"GUI: {session.device_type=}")
-        logging.debug(f"GUI: {Window.size=}")
 
         super().__init__(**kwargs)
         ExceptionManager.add_handler(AppExceptionHandler())
@@ -99,6 +98,12 @@ class NetworkPuzzlesApp(App):
 
         self.packetmgr = PacketManager(self)
         Clock.schedule_interval(self._update_packets, self.packet_tick_delay)
+
+        # Log config details.
+        for sect, data in Config._sections.items():
+            logging.debug(f"CONFIG: {sect}:")
+            for k, v in data.items():
+                logging.debug(f"CONFIG:  {k} = {v}")
 
     @property
     def devices(self):

--- a/src/network_puzzles/gui/__init__.py
+++ b/src/network_puzzles/gui/__init__.py
@@ -567,9 +567,10 @@ class TerminalLabel(TextInput):
             # grab status and re-grab if needed.
             super().on_touch_down(touch)
             if touch.button is None and touch.grab_current is not self:
-                logging.debug(f"App: {touch.grab_current=}")
-                touch.grab(self)
-                logging.debug(f"App: (after grab) {touch.grab_current=}")
+                logging.debug(f"App: pre-grab: {touch.grab_current=}")
+                # touch.grab(self)
+                touch.grab_current = self
+                logging.debug(f"App: post-grab: {touch.grab_current=}")
             return True
 
     def on_touch_move(self, touch):

--- a/src/network_puzzles/gui/__init__.py
+++ b/src/network_puzzles/gui/__init__.py
@@ -560,16 +560,27 @@ class NetworkPuzzlesApp(App):
 
 class TerminalLabel(TextInput):
     def on_touch_down(self, touch):
-        # logging.debug(f"App: touch down at: {touch.pos}; {touch.__dict__}")
         logging.debug(f"App: {self.__class__.__name__=}")
         for a in sorted(self.__dir__()):
             if hasattr(self, a) and not a.startswith("__"):
                 logging.debug(f"App:  {a} = {getattr(self, a)}")
-        # if touch.button is None and self.collide_point(*touch.pos):
-        #     touch.grab(self)
-        #     return True
-        # if super().on_touch_down(touch):
-        #     return True
+        logging.debug(f"App: {touch.__class__.__name__=}")
+        for a in sorted(touch.__dir__()):
+            if hasattr(touch, a) and not a.startswith("__"):
+                logging.debug(f"App: {a} = {getattr(touch, a)}")
+
+        ret = super().on_touch_down(touch)
+
+        logging.debug(f"App: {self.__class__.__name__=}")
+        for a in sorted(self.__dir__()):
+            if hasattr(self, a) and not a.startswith("__"):
+                logging.debug(f"App:  {a} = {getattr(self, a)}")
+        logging.debug(f"App: {touch.__class__.__name__=}")
+        for a in sorted(touch.__dir__()):
+            if hasattr(touch, a) and not a.startswith("__"):
+                logging.debug(f"App: {a} = {getattr(touch, a)}")
+        if ret:
+            return ret
 
     def on_touch_up(self, touch):
         logging.debug(f"App: touch up at: {touch.pos}; {touch.__dict__}")

--- a/src/network_puzzles/gui/__init__.py
+++ b/src/network_puzzles/gui/__init__.py
@@ -81,7 +81,7 @@ class NetworkPuzzlesApp(App):
             logger.level = logging.DEBUG
             self.packet_tick_delay = 0.04  # packet pos refresh rate in seconds
             self.packet_progress_rate = 6  # % of link traveled each tick
-        logging.debug(f"GUI: {session.device_type=}")
+        logging.debug(f"App: {session.device_type=}")
 
         super().__init__(**kwargs)
         ExceptionManager.add_handler(AppExceptionHandler())
@@ -101,9 +101,9 @@ class NetworkPuzzlesApp(App):
 
         # Log config details.
         for sect, data in Config._sections.items():
-            logging.debug(f"CONFIG: {sect}:")
+            logging.debug(f"Config: {sect}:")
             for k, v in data.items():
-                logging.debug(f"CONFIG:  {k} = {v}")
+                logging.debug(f"Config:  {k} = {v}")
 
     @property
     def devices(self):
@@ -183,7 +183,7 @@ class NetworkPuzzlesApp(App):
     def draw_puzzle(self, *args):
         """Clear puzzle layout area; draw all elements related to current puzzle."""
         logging.debug(
-            f"GUI: {self.root.ids.layout.__class__.__name__}: pos={self.root.ids.layout.pos}; size={self.root.ids.layout.size}"
+            f"App: {self.root.ids.layout.__class__.__name__}: pos={self.root.ids.layout.pos}; size={self.root.ids.layout.size}"
         )
         if not self.ui.puzzle:
             logging.warning("GUI: No puzzle is loaded.")
@@ -194,7 +194,7 @@ class NetworkPuzzlesApp(App):
         # Get puzzle text from localized messages, if possible, but fallback to
         # English text in JSON data.
         puzzle_data = self.ui.puzzle.json
-        logging.debug(f"GUI: {self.ui.puzzle.uid=}")
+        logging.debug(f"App: {self.ui.puzzle.uid=}")
         puzzle_messages = messages.puzzles.get(self.ui.puzzle.uid)
         if puzzle_messages:
             title = puzzle_messages.get("title")
@@ -277,7 +277,7 @@ class NetworkPuzzlesApp(App):
             Clock.schedule_once(self.on_puzzle_chooser)
 
     def on_touch_down(self, touch):
-        logging.debug(f"GUI: touch registered at: {touch.pos}")
+        logging.debug(f"App: touch registered at: {touch.pos}")
         super().on_touch_down(touch)
 
     def on_undo(self):
@@ -301,10 +301,10 @@ class NetworkPuzzlesApp(App):
         self.title = self.app_title
         # Remove any remaining child widgets from puzzle layout.
         self.root.ids.layout.clear_widgets()
-        logging.debug(f"GUI: display: window size: {Window.size}")
-        # logging.debug(f"GUI: puzzle layout width: {self.root.ids.layout.width}")
-        logging.debug(f"GUI: display: layout height: {self.root.ids.layout.height}")
-        logging.debug(f"GUI: display: terminal height: {self.root.ids.terminal.height}")
+        logging.debug(f"App: window size: {Window.size}")
+        # logging.debug(f"App: puzzle layout width: {self.root.ids.layout.width}")
+        logging.debug(f"App: layout height: {self.root.ids.layout.height}")
+        logging.debug(f"App: terminal height: {self.root.ids.terminal.height}")
         # Redraw the "+" button for adding new items.
         self.root.ids.layout.add_items_menu_button()
 
@@ -372,20 +372,20 @@ class NetworkPuzzlesApp(App):
         if not hasattr(self, "chosen_device"):
             self.chosen_device = None
         elif self.chosen_device:
-            logging.info(f"GUI: User selected device: {self.chosen_device.hostname}")
+            logging.info(f"App: User selected device: {self.chosen_device.hostname}")
 
     def user_select_nic(self, devicew):
         if not hasattr(self, "chosen_nic"):
             self.chosen_nic = None
             ChooseNicPopup(devicew).open()
         elif self.chosen_nic:
-            logging.info(f"GUI: User selected NIC: {self.chosen_nic}")
+            logging.info(f"App: User selected NIC: {self.chosen_nic}")
 
     def user_select_position(self):
         if not hasattr(self, "chosen_pos"):
             self.chosen_pos = None
         elif self.chosen_pos:
-            logging.info(f"GUI: User selected pos: {self.chosen_pos}")
+            logging.info(f"App: User selected pos: {self.chosen_pos}")
 
     def _get_widget_by_prop(self, prop, value):
         for w in self.root.ids.layout.children:
@@ -425,7 +425,7 @@ class NetworkPuzzlesApp(App):
             for n, t in ((test.shost, test.name) for test in uncompleted_tests):
                 d = self.ui.get_device(n)
                 if d is None:
-                    logging.info(f'Ignoring highlight of non-device "{n}"')
+                    logging.info(f'App: Ignoring highlight of non-device "{n}"')
                     continue
                 w = self.get_widget_by_hostname(n)
                 if isinstance(w, Device) and not w.base.is_invisible:

--- a/src/network_puzzles/gui/__init__.py
+++ b/src/network_puzzles/gui/__init__.py
@@ -162,10 +162,7 @@ class NetworkPuzzlesApp(App):
     def add_terminal_line(self, line):
         if not line.endswith("\n"):
             line += "\n"
-        logging.debug(
-            f"GUI: scroll_from_swipe: {self.root.ids.terminal.scroll_from_swipe}"
-        )
-        self.root.ids.terminal.text += f"{line}"
+        self.root.ids.terminal.text += f"{self.ui.PS1} {line}"
 
     def draw_devices(self, *args):
         for dev in self.ui.puzzle.devices:

--- a/src/network_puzzles/gui/__init__.py
+++ b/src/network_puzzles/gui/__init__.py
@@ -560,38 +560,38 @@ class NetworkPuzzlesApp(App):
 
 
 class TerminalLabel(TextInput):
-    def on_touch_down(self, touch):
-        if self.collide_point(*touch.pos):
-            # NOTE: On mobile (touchscreen device) when TextInput is readonly
-            # touch.grab_current fails in super().on_touch_down(touch) because
-            # readonly attrib forces self.is_focusable = False during
-            # FocusBehavior.on_touch_down(touch):
-            # Ref: https://github.com/kivy/kivy/blob/8d6ce56d6233b40f74608b33f4dc7ded14869d1d/kivy/uix/behaviors/focus.py#L464C1-L472C63
-            # class FocusBehavior:
-            # [...]
-            #     def on_touch_down(self, touch):
-            #         if not self.collide_point(*touch.pos):
-            #             return
-            #         if (not self.disabled and self.is_focusable and
-            #             ('button' not in touch.profile or
-            #                 not touch.button.startswith('scroll'))):
-            #             self.focus = True
-            #             FocusBehavior.ignored_touch.append(touch)
-            #         return super(FocusBehavior, self).on_touch_down(touch)
-            # Workaround: preempt FocusBehavior.on_touch_down.
-            if "button" not in touch.profile:
-                logging.debug("App: Overriding FocusBehvaior.on_touch_down(touch)")
-                self.focus = True
-                FocusBehavior.ignored_touch.append(touch)
-                result = super(FocusBehavior, self).on_touch_down(touch)
-                logging.debug(f"App: super(FocusBehavior) {result=}")
-                logging.debug("App: Post-override:")
-                for attrib in sorted(self.__dir__()):
-                    if not attrib.startswith("__"):
-                        logging.debug(f"App:  {attrib} = {getattr(self, attrib)}")
-                return result if result else True
-            else:
-                return super().on_touch_down(touch)
+    # def on_touch_down(self, touch):
+    #     if self.collide_point(*touch.pos):
+    #         # NOTE: On mobile (touchscreen device) when TextInput is readonly
+    #         # touch.grab_current fails in super().on_touch_down(touch) because
+    #         # readonly attrib forces self.is_focusable = False during
+    #         # FocusBehavior.on_touch_down(touch):
+    #         # Ref: https://github.com/kivy/kivy/blob/8d6ce56d6233b40f74608b33f4dc7ded14869d1d/kivy/uix/behaviors/focus.py#L464C1-L472C63
+    #         # class FocusBehavior:
+    #         # [...]
+    #         #     def on_touch_down(self, touch):
+    #         #         if not self.collide_point(*touch.pos):
+    #         #             return
+    #         #         if (not self.disabled and self.is_focusable and
+    #         #             ('button' not in touch.profile or
+    #         #                 not touch.button.startswith('scroll'))):
+    #         #             self.focus = True
+    #         #             FocusBehavior.ignored_touch.append(touch)
+    #         #         return super(FocusBehavior, self).on_touch_down(touch)
+    #         # Workaround: preempt FocusBehavior.on_touch_down.
+    #         if "button" not in touch.profile:
+    #             logging.debug("App: Overriding FocusBehvaior.on_touch_down(touch)")
+    #             self.focus = True
+    #             FocusBehavior.ignored_touch.append(touch)
+    #             # result = super(FocusBehavior, self).on_touch_down(touch) # no need to propagate touch
+    #             # logging.debug(f"App: super(FocusBehavior) {result=}")
+    #             logging.debug("App: Post-override:")
+    #             for attrib in sorted(self.__dir__()):
+    #                 if not attrib.startswith("__"):
+    #                     logging.debug(f"App:  {attrib} = {getattr(self, attrib)}")
+    #             return True
+    #         else:
+    #             return super().on_touch_down(touch)
 
     def on_touch_up(self, touch):
         # REF: https://kivy.org/doc/master/guide/inputs.html#grabbing-touch-events

--- a/src/network_puzzles/gui/__init__.py
+++ b/src/network_puzzles/gui/__init__.py
@@ -74,6 +74,8 @@ class NetworkPuzzlesApp(App):
             self.packet_tick_delay = 0.02  # packet pos refresh rate in seconds
             self.packet_progress_rate = 3  # % of link traveled each tick
         else:  # mobile devices
+            # Force orientation to landscape.
+            Window.orientation = 0
             # Force loglevel to DEBUG.
             logger = logging.getLogger()
             logger.level = logging.DEBUG

--- a/src/network_puzzles/gui/__init__.py
+++ b/src/network_puzzles/gui/__init__.py
@@ -560,6 +560,17 @@ class NetworkPuzzlesApp(App):
 
 class TerminalLabel(TextInput):
     def on_touch_down(self, touch):
+        if self.collide_point(*touch.pos):
+            # NOTE: On mobile (touchscreen device) when TextInput is readonly
+            # touch.grab(self) seems to fail in super().on_touch_down(touch).
+            # Workaround is to run super().on_touch_down(touch), then check for
+            # grab status and re-grab if needed.
+            super().on_touch_down(touch)
+            if touch.button is None and touch.grab_current is not self:
+                touch.grab(self)
+            return True
+
+    def on_touch_move(self, touch):
         logging.debug(f"App: {self.__class__.__name__=}")
         for a in sorted(self.__dir__()):
             if hasattr(self, a) and not a.startswith("__"):
@@ -569,12 +580,8 @@ class TerminalLabel(TextInput):
             if hasattr(touch, a) and not a.startswith("__"):
                 logging.debug(f"App: {a} = {getattr(touch, a)}")
 
-        ret = super().on_touch_down(touch)
+        ret = super().on_touch_move(touch)
 
-        logging.debug(f"App: {self.__class__.__name__=}")
-        for a in sorted(self.__dir__()):
-            if hasattr(self, a) and not a.startswith("__"):
-                logging.debug(f"App:  {a} = {getattr(self, a)}")
         logging.debug(f"App: {touch.__class__.__name__=}")
         for a in sorted(touch.__dir__()):
             if hasattr(touch, a) and not a.startswith("__"):

--- a/src/network_puzzles/gui/__init__.py
+++ b/src/network_puzzles/gui/__init__.py
@@ -13,6 +13,8 @@ from .. import session
 if session.device_type == "desktop":
     # Disable right-click red dot.
     Config.set("input", "mouse", "mouse,disable_multitouch")
+elif session.device_type == "mobile":
+    Config.set("kivy", "desktop", "0")
 
 # Continue with remaining imports.
 from kivy.app import App
@@ -562,9 +564,10 @@ class NetworkPuzzlesApp(App):
 
 class TerminalLabel(TextInput):
     def on_touch_up(self, touch):
+        logging.debug(f"App: {touch.pos=}; {touch.profile=}")
         # REF: https://kivy.org/doc/master/guide/inputs.html#grabbing-touch-events
         # Open popup on right-click within the Terminal area (only works on
-        # desktop devices).
+        # desktop devices, where touch.button is not None).
         if touch.button == "right" and touch.grab_current is self:
             touch.ungrab(self)
             CommandPopup().open()

--- a/src/network_puzzles/gui/__init__.py
+++ b/src/network_puzzles/gui/__init__.py
@@ -584,11 +584,12 @@ class TerminalLabel(TextInput):
                 self.focus = True
                 FocusBehavior.ignored_touch.append(touch)
                 result = super(FocusBehavior, self).on_touch_down(touch)
+                logging.debug(f"App: super(FocusBehavior) {result=}")
                 logging.debug("App: Post-override:")
                 for attrib in sorted(self.__dir__()):
                     if not attrib.startswith("__"):
                         logging.debug(f"App:  {attrib} = {getattr(self, attrib)}")
-                return result
+                return result if result else True
             else:
                 return super().on_touch_down(touch)
 

--- a/src/network_puzzles/gui/__init__.py
+++ b/src/network_puzzles/gui/__init__.py
@@ -580,15 +580,19 @@ class TerminalLabel(TextInput):
             #         return super(FocusBehavior, self).on_touch_down(touch)
             # Workaround: preempt FocusBehavior.on_touch_down.
             if "button" not in touch.profile:
+                logging.debug("App: Overriding FocusBehvaior.on_touch_down(touch)")
                 self.focus = True
                 FocusBehavior.ignored_touch.append(touch)
                 super(FocusBehavior, self).on_touch_down(touch)
+                logging.debug("App: Post-override:")
+                for k, v in self.__dir__().items():
+                    if not k.startswith("__"):
+                        logging.debug(f"App:  {k} = {v}")
                 return True
             else:
                 return super().on_touch_down(touch)
 
     def on_touch_up(self, touch):
-        logging.debug(f"App: touch up at: {touch.pos}; {touch.__dict__}")
         # REF: https://kivy.org/doc/master/guide/inputs.html#grabbing-touch-events
         # Open popup on right-click within the Terminal area (only works on
         # desktop devices, where touch.button is not None).

--- a/src/network_puzzles/gui/__init__.py
+++ b/src/network_puzzles/gui/__init__.py
@@ -559,26 +559,30 @@ class NetworkPuzzlesApp(App):
 
 
 class TerminalLabel(TextInput):
-    def on_touch_down(self, touch):
-        if self.collide_point(*touch.pos):
-            # NOTE: On mobile (touchscreen device) when TextInput is readonly
-            # touch.grab(self) seems to fail in super().on_touch_down(touch).
-            # Workaround is to run super().on_touch_down(touch), then check for
-            # grab status and re-grab if needed.
-            super().on_touch_down(touch)
-            if touch.button is None and touch.grab_current is not self:
-                logging.debug(f"App: pre-grab: {touch.grab_current=}")
-                # touch.grab(self)
-                touch.grab_current = self
-                logging.debug(f"App: post-grab: {touch.grab_current=}")
-            return True
+    # def on_touch_down(self, touch):
+    #     if self.collide_point(*touch.pos):
+    #         # NOTE: On mobile (touchscreen device) when TextInput is readonly
+    #         # touch.grab(self) seems to fail in super().on_touch_down(touch).
+    #         # Workaround is to run super().on_touch_down(touch), then check for
+    #         # grab status and re-grab if needed.
+    #         super().on_touch_down(touch)
+    #         if touch.button is None and touch.grab_current is not self:
+    #             logging.debug(f"App: pre-grab: {self.focus=}")
+    #             logging.debug(f"App: pre-grab: {touch.grab_current=}")
+    #             # touch.grab(self)
+    #             touch.grab_current = self
+    #             logging.debug(f"App: post-grab: {self.focus=}")
+    #             logging.debug(f"App: post-grab: {touch.grab_current=}")
+    #         return True
 
     def on_touch_move(self, touch):
-        logging.debug(f"App: {touch.grab_list=}")
-        logging.debug(f"App: {touch.grab_current=}")
+        logging.debug(f"App: pre-super: {self.focus=}")
+        logging.debug(f"App: pre-super: {touch.grab_list=}")
+        logging.debug(f"App: pre-super: {touch.grab_current=}")
         ret = super().on_touch_move(touch)
-        logging.debug(f"App: (after super) {touch.grab_list=}")
-        logging.debug(f"App: (after super) {touch.grab_current=}")
+        logging.debug(f"App: post-super: {self.focus=}")
+        logging.debug(f"App: post-super {touch.grab_list=}")
+        logging.debug(f"App: post-super {touch.grab_current=}")
         if ret:
             return ret
 

--- a/src/network_puzzles/gui/__init__.py
+++ b/src/network_puzzles/gui/__init__.py
@@ -559,32 +559,29 @@ class NetworkPuzzlesApp(App):
 
 
 class TerminalLabel(TextInput):
-    # def on_touch_down(self, touch):
-    #     if self.collide_point(*touch.pos):
-    #         # NOTE: On mobile (touchscreen device) when TextInput is readonly
-    #         # touch.grab(self) seems to fail in super().on_touch_down(touch).
-    #         # Workaround is to run super().on_touch_down(touch), then check for
-    #         # grab status and re-grab if needed.
-    #         super().on_touch_down(touch)
-    #         if touch.button is None and touch.grab_current is not self:
-    #             logging.debug(f"App: pre-grab: {self.focus=}")
-    #             logging.debug(f"App: pre-grab: {touch.grab_current=}")
-    #             # touch.grab(self)
-    #             touch.grab_current = self
-    #             logging.debug(f"App: post-grab: {self.focus=}")
-    #             logging.debug(f"App: post-grab: {touch.grab_current=}")
-    #         return True
+    def on_touch_down(self, touch):
+        if self.collide_point(*touch.pos):
+            # NOTE: On mobile (touchscreen device) when TextInput is readonly
+            # touch.grab_current fails in super().on_touch_down(touch) because
+            # readonly attrib forces self.is_focusable = False during
+            # FocusBehavior.on_touch_down(touch).
+            # Workaround is to manually set self.is_focusable before
+            # super().on_touch_down(touch).
+            self.is_focusable = True
+            super().on_touch_down(touch)
+            self.is_focusable = False
+            return True
 
-    def on_touch_move(self, touch):
-        logging.debug(f"App: pre-super: {self.focus=}")
-        logging.debug(f"App: pre-super: {touch.grab_list=}")
-        logging.debug(f"App: pre-super: {touch.grab_current=}")
-        ret = super().on_touch_move(touch)
-        logging.debug(f"App: post-super: {self.focus=}")
-        logging.debug(f"App: post-super {touch.grab_list=}")
-        logging.debug(f"App: post-super {touch.grab_current=}")
-        if ret:
-            return ret
+    # def on_touch_move(self, touch):
+    #     logging.debug(f"App: pre-super: {self.focus=}")
+    #     logging.debug(f"App: pre-super: {touch.grab_list=}")
+    #     logging.debug(f"App: pre-super: {touch.grab_current=}")
+    #     ret = super().on_touch_move(touch)
+    #     logging.debug(f"App: post-super: {self.focus=}")
+    #     logging.debug(f"App: post-super {touch.grab_list=}")
+    #     logging.debug(f"App: post-super {touch.grab_current=}")
+    #     if ret:
+    #         return ret
 
     def on_touch_up(self, touch):
         logging.debug(f"App: touch up at: {touch.pos}; {touch.__dict__}")

--- a/src/network_puzzles/gui/__init__.py
+++ b/src/network_puzzles/gui/__init__.py
@@ -560,13 +560,16 @@ class NetworkPuzzlesApp(App):
 
 class TerminalLabel(TextInput):
     def on_touch_down(self, touch):
-        logging.debug(f"App: touch down at: {touch.pos}; {touch.__dict__}")
-        logging.debug(f"App: {self.use_handles=}")
+        # logging.debug(f"App: touch down at: {touch.pos}; {touch.__dict__}")
         logging.debug(f"App: {self.__class__.__name__=}")
         for a in sorted(self.__dir__()):
-            if hasattr(self, a) and not a.startswith("_"):
+            if hasattr(self, a) and not a.startswith("__"):
                 logging.debug(f"App:  {a} = {getattr(self, a)}")
-        return super().on_touch_down(touch)
+        # if touch.button is None and self.collide_point(*touch.pos):
+        #     touch.grab(self)
+        #     return True
+        # if super().on_touch_down(touch):
+        #     return True
 
     def on_touch_up(self, touch):
         logging.debug(f"App: touch up at: {touch.pos}; {touch.__dict__}")
@@ -577,7 +580,6 @@ class TerminalLabel(TextInput):
             touch.ungrab(self)
             CommandPopup().open()
             return True
-        return super().on_touch_up(touch)
 
 
 class AppExceptionHandler(ExceptionHandler):

--- a/src/network_puzzles/gui/__init__.py
+++ b/src/network_puzzles/gui/__init__.py
@@ -278,10 +278,6 @@ class NetworkPuzzlesApp(App):
         if not self.ui.puzzle:
             Clock.schedule_once(self.on_puzzle_chooser)
 
-    def on_touch_down(self, touch):
-        logging.debug(f"App: touch registered at: {touch.pos}")
-        super().on_touch_down(touch)
-
     def on_undo(self):
         self.ui.undo()
 
@@ -563,8 +559,12 @@ class NetworkPuzzlesApp(App):
 
 
 class TerminalLabel(TextInput):
+    def on_touch_down(self, touch):
+        logging.debug(f"App: touch down at: {touch.pos}; {touch.__dict__}")
+        return super().on_touch_down(touch)
+
     def on_touch_up(self, touch):
-        logging.debug(f"App: {touch.pos=}; {touch.profile=}")
+        logging.debug(f"App: touch up at: {touch.pos}; {touch.__dict__}")
         # REF: https://kivy.org/doc/master/guide/inputs.html#grabbing-touch-events
         # Open popup on right-click within the Terminal area (only works on
         # desktop devices, where touch.button is not None).
@@ -572,6 +572,7 @@ class TerminalLabel(TextInput):
             touch.ungrab(self)
             CommandPopup().open()
             return True
+        return super().on_touch_down(touch)
 
 
 class AppExceptionHandler(ExceptionHandler):

--- a/src/network_puzzles/gui/base.py
+++ b/src/network_puzzles/gui/base.py
@@ -174,8 +174,8 @@ def location_to_pos(location: iter, size) -> tuple:
     """Converts EduNetworkBuilder's location coords to relative layout's position."""
     if len(location) != 2:
         raise ValueError(f"GUI: location length != 2: {location}")
+    logging.debug(f"L2P: input location: {location}")
     # Get relative location (invert y-coord).
-    # logging.debug(f"GUI: input location: {location}")
     effective_rel_pos = (
         location[0] / LOCATION_MAX_X,
         1 - (location[1] / LOCATION_MAX_Y),

--- a/src/network_puzzles/gui/base.py
+++ b/src/network_puzzles/gui/base.py
@@ -161,7 +161,7 @@ def get_layout_height(layout) -> int:
 
 
 def hide_widget(wid, do_hide=True):
-    # logging.debug(f"GUI: hide {wid.hostname}={do_hide}")
+    # logging.debug(f"Base: hide {wid.hostname}={do_hide}")
     if hasattr(wid, "opacity_prev") and not do_hide:
         wid.opacity = wid.opacity_prev
         del wid.opacity_prev
@@ -174,34 +174,34 @@ def location_to_pos(location: iter, size) -> tuple:
     """Converts EduNetworkBuilder's location coords to relative layout's position."""
     if len(location) != 2:
         raise ValueError(f"GUI: location length != 2: {location}")
-    logging.debug(f"L2P: input location: {location}")
+    logging.debug(f"Base: input location: {location}")
     # Get relative location (invert y-coord).
     effective_rel_pos = (
         location[0] / LOCATION_MAX_X,
         1 - (location[1] / LOCATION_MAX_Y),
     )
-    logging.debug(f"L2P: effective area rel pos: {effective_rel_pos}")
+    logging.debug(f"Base: effective area rel pos: {effective_rel_pos}")
     # Calculate proportial pos within non-padded puzzle area.
     effective_pos = rel_pos_to_pos(effective_rel_pos, get_effective_size(size))
-    logging.debug(f"L2P: effective area pos: {effective_pos}")
+    logging.debug(f"Base: effective area pos: {effective_pos}")
     # Calculate abs pos by taking padding into account.
     pos = (PADDING + effective_pos[0], PADDING + effective_pos[1])
-    logging.debug(f"L2P: {location=} -> {pos=}")
+    logging.debug(f"Base: {location=} -> {pos=}")
     return pos
 
 
 def location_to_rel_pos(location: iter, size) -> tuple:
     if len(location) != 2:
-        raise ValueError(f"GUI: location length != 2: {location}")
+        raise ValueError(f"Base: location length != 2: {location}")
     pos = location_to_pos(location, size)
     rel_pos = pos_to_rel_pos(pos, size)
-    logging.debug(f"GUI: {location=} -> {rel_pos=}")
+    logging.debug(f"Base: {location=} -> {rel_pos=}")
     return rel_pos
 
 
 def pos_to_location(pos, size) -> tuple:
     """Converts relative layout's position to EduNetworkBuilder's location coords."""
-    # logging.debug(f"GUI: input pos: {pos}")
+    # logging.debug(f"Base: input pos: {pos}")
     x = pos[0]
     y = pos[1]
 
@@ -214,72 +214,74 @@ def pos_to_location(pos, size) -> tuple:
         y = PADDING
     if y > size[1] - PADDING:
         y = size[1] - PADDING
-    # logging.debug(f"GUI: limited pos: ({x}, {y})")
+    # logging.debug(f"Base: limited pos: ({x}, {y})")
 
     # Subtract padding to get pos in effective puzzle area.
     effective_pos = (x - PADDING, y - PADDING)
-    # logging.debug(f"GUI: effective area pos: {effective_pos}")
+    # logging.debug(f"Base: effective area pos: {effective_pos}")
     # Divide by effective area l/w to get relative pos in effective area.
     effective_rel_pos = pos_to_rel_pos(effective_pos, get_effective_size(size))
-    # logging.debug(f"GUI: effective area rel pos: {effective_rel_pos}")
+    # logging.debug(f"Base: effective area rel pos: {effective_rel_pos}")
     # Multiply by location max values to get location value (invert y-axis).
     loc = (
         round(effective_rel_pos[0] * LOCATION_MAX_X),
         round((1 - effective_rel_pos[1]) * LOCATION_MAX_Y),
     )
-    logging.debug(f"GUI: {pos=} -> {loc=}")
+    logging.debug(f"Base: {pos=} -> {loc=}")
     return loc
 
 
 def pos_to_rel_pos(pos, size) -> tuple:
     """Convert absolute position to relative decimal values from 0 to 1."""
     rel_pos = (pos[0] / size[0], pos[1] / size[1])
-    # logging.debug(f"GUI: {size=}; {pos=} -> {rel_pos=}")
+    # logging.debug(f"Base: {size=}; {pos=} -> {rel_pos=}")
     return rel_pos
 
 
 def rel_pos_to_pos(rel_pos, size) -> tuple:
     """Convert relative decimal value position to absolute position."""
     pos = (rel_pos[0] * size[0], rel_pos[1] * size[1])
-    # logging.debug(f"GUI: {rel_pos=} -> {pos=}; {size=}")
+    # logging.debug(f"Base: {rel_pos=} -> {pos=}; {size=}")
     return pos
 
 
 def print_layout_info(app):
     # Layout debug logging.
     layout = app.root.ids.layout
-    logging.debug(f"GUI: {layout.__class__.__name__} corner: {layout.pos}")
-    logging.debug(f"GUI: {layout.__class__.__name__} size: {layout.size}")
+    logging.debug(f"Base: {layout.__class__.__name__} corner: {layout.pos}")
+    logging.debug(f"Base: {layout.__class__.__name__} size: {layout.size}")
     w = layout.size[0] - 2 * PADDING
     h = layout.size[1] - 2 * PADDING
     x = layout.x + PADDING
     y = layout.y + PADDING
-    logging.debug(f"GUI: {layout.__class__.__name__} effective corner: [{x}, {y}]")
-    logging.debug(f"GUI: {layout.__class__.__name__} effective size: [{w}, {h}]")
-    logging.debug(f"GUI: {layout.__class__.__name__} elements:")
+    logging.debug(f"Base: {layout.__class__.__name__} effective corner: [{x}, {y}]")
+    logging.debug(f"Base: {layout.__class__.__name__} effective size: [{w}, {h}]")
+    logging.debug(f"Base: {layout.__class__.__name__} elements:")
     for w in layout.children:
         if hasattr(w, "hostname"):
             logging.debug(
-                f"GUI: - {w.__class__.__name__}/{w.hostname}: {w.center=}; {w.pos=}; {w.size=}"
+                f"Base: - {w.__class__.__name__}/{w.hostname}: {w.center=}; {w.pos=}; {w.size=}"
             )
             if hasattr(w, "get_height"):  # layout
-                logging.debug(f"GUI: -- {w.get_height()=}")
-                logging.debug(f"GUI: -- {w.drag_rectangle=}")
+                logging.debug(f"Base: -- {w.get_height()=}")
+                logging.debug(f"Base: -- {w.drag_rectangle=}")
         else:
             logging.debug(
-                f"GUI: - {w.__class__.__name__}: {w.center=}; {w.pos=}; {w.size=}"
+                f"Base: - {w.__class__.__name__}: {w.center=}; {w.pos=}; {w.size=}"
             )
 
 
 def show_grid(app):
     """Add grid dots at all major intersections to verify device alignment."""
     layout = app.root.ids.layout
-    logging.debug(f"GUI: {layout.size=}")
+    logging.debug(f"Base: {layout.size=}")
     with layout.canvas.after:
         Color(1, 0, 0)
         for x in range(0, 1000, 100):
             for y in range(0, 900, 100):
                 local_pos = location_to_pos((x, y), layout.size)
                 pos = layout.to_window(*local_pos, initial=False)
-                logging.debug(f"GUI: loc: ({x}, {y}); abs pos: {local_pos}; pos: {pos}")
+                logging.debug(
+                    f"Base: loc: ({x}, {y}); abs pos: {local_pos}; pos: {pos}"
+                )
                 Ellipse(pos=pos, size=(5, 5))

--- a/src/network_puzzles/gui/base.py
+++ b/src/network_puzzles/gui/base.py
@@ -180,13 +180,13 @@ def location_to_pos(location: iter, size) -> tuple:
         location[0] / LOCATION_MAX_X,
         1 - (location[1] / LOCATION_MAX_Y),
     )
-    # logging.debug(f"GUI: effective area rel pos: {effective_rel_pos}")
+    logging.debug(f"L2P: effective area rel pos: {effective_rel_pos}")
     # Calculate proportial pos within non-padded puzzle area.
     effective_pos = rel_pos_to_pos(effective_rel_pos, get_effective_size(size))
-    # logging.debug(f"GUI: effective area pos: {effective_pos}")
+    logging.debug(f"L2P: effective area pos: {effective_pos}")
     # Calculate abs pos by taking padding into account.
     pos = (PADDING + effective_pos[0], PADDING + effective_pos[1])
-    logging.debug(f"GUI: {location=} -> {pos=}")
+    logging.debug(f"L2P: {location=} -> {pos=}")
     return pos
 
 

--- a/src/network_puzzles/gui/buttons.py
+++ b/src/network_puzzles/gui/buttons.py
@@ -113,7 +113,7 @@ class ThemedButton(Button):
             return
         self.tooltip_text = self.info
         if self.tooltip_anchor is None:
-            logging.warning(f"GUI: {self} has no tooltip_anchor!")
+            logging.warning(f"Buttons: {self} has no tooltip_anchor!")
             return
         if self.tooltip not in self.tooltip_anchor.children:
             self.tooltip_anchor.add_widget(self.tooltip)
@@ -124,7 +124,7 @@ class ThemedButton(Button):
         x = self.x + self.width + sp
         y = self.y + self.height - self.tooltip.height
         if self.tooltip_anchor is None:
-            logging.warning(f"GUI: {self} has no tooltip_anchor!")
+            logging.warning(f"Buttons: {self} has no tooltip_anchor!")
             return (x, y)
         if x + self.tooltip.width > self.tooltip_anchor.width:
             # Put the tooltip to the left if not enough room to the right.

--- a/src/network_puzzles/gui/buttons.py
+++ b/src/network_puzzles/gui/buttons.py
@@ -19,7 +19,7 @@ class ThemedButton(Button):
         self.long_press = None
         self.tooltip = ToolTip()
         self._on_release = on_release
-        Window.bind(mouse_pos=self.on_mouse_pos)
+        # Window.bind(mouse_pos=self.on_mouse_pos)
 
     @property
     def app(self):
@@ -66,12 +66,10 @@ class ThemedButton(Button):
     def on_mouse_pos(self, window, pos):
         if not self.get_root_window():
             return
-        w_pos = self.to_widget(*pos)
         # Close tooltip if already open.
         self.cancel_tooltip()
-        # Clock.unschedule(self.open_tooltip)  # cursor moved, cancel scheduled event
-        # self.close_tooltip()  # close if it's opened
-        if self.collide_point(*w_pos):
+        # w_pos = self.to_widget(*pos)
+        if self.collide_point(*self.to_widget(*pos)):
             Clock.schedule_once(self.open_tooltip, 1)
 
     def on_press(self):

--- a/src/network_puzzles/gui/buttons.py
+++ b/src/network_puzzles/gui/buttons.py
@@ -19,7 +19,7 @@ class ThemedButton(Button):
         self.long_press = None
         self.tooltip = ToolTip()
         self._on_release = on_release
-        # Window.bind(mouse_pos=self.on_mouse_pos)
+        Window.bind(mouse_pos=self.on_mouse_pos)
 
     @property
     def app(self):
@@ -68,9 +68,9 @@ class ThemedButton(Button):
             return
         # Close tooltip if already open.
         self.cancel_tooltip()
-        # w_pos = self.to_widget(*pos)
+        # Open trigger button's toolip if mouse is over button.
         if self.collide_point(*self.to_widget(*pos)):
-            Clock.schedule_once(self.open_tooltip, 1)
+            Clock.schedule_once(self.open_tooltip, self.LONG_PRESS_THRESHOLD)
 
     def on_press(self):
         if self._on_release is None:

--- a/src/network_puzzles/gui/devices.kv
+++ b/src/network_puzzles/gui/devices.kv
@@ -27,20 +27,14 @@
         ThemedBoxLayout:  # left 1/3
             id: left_panel
             size_hint_x: 0.3
+            size_hint_min_y: 3 * app.BUTTON_MAX_H
             orientation: "vertical"
             SingleRowLayout:
-                size_hint_y: 0.16
-                #size_hint_max_y: app.BUTTON_MAX_H + dp(8)
                 CheckBoxLabel:  # Hostname
                     text: _("Hostname")
                 ValueInput:  # device.hostname
                     text: root.device.hostname
-            #PopupButton:  # Gateway
-            #    text: _("Gateway")
-            #    on_release: root.on_gateway()
             SingleRowLayout:
-                size_hint_y: 0.16
-                #size_hint_max_y: app.BUTTON_MAX_H + dp(8)
                 CheckBoxLabel:  # Gateway
                     text: _("Gateway")
                 ValueInput:  # device.gateway
@@ -54,15 +48,13 @@
             size_hint_x: 0.3
             orientation: "vertical"
             SingleRowLayout:  # NICs label/button
-                size_hint_y: 0.15
                 CheckBoxLabel:  # NICs
-                    size_hint_x: 0.2
+                    size_hint_x: 0.25
                     text: _("NICs")
                 PopupButton:  # +
                     id: add_nic
                     size_hint_x: 0.15
                     text: "+"
-                    #disabled: True
                     on_release: root.on_nics_add()
                 PopupButton:  # replace
                     id: remove_nic
@@ -72,7 +64,7 @@
                     on_release: root.on_nics_replace()
                 PopupButton:  # Edit
                     id: edit_nic
-                    size_hint_x: 0.5
+                    size_hint_x: 0.45
                     text: _("Edit")
                     disabled: True
                     on_release: root.on_nics_edit()
@@ -82,9 +74,8 @@
                 root: root
                 on_parent: self.update_data(root.device.nics, management=True)
             SingleRowLayout:  # IPs label/buttons
-                size_hint_y: 0.15
                 CheckBoxLabel:  # IPs
-                    size_hint_x: 0.2
+                    size_hint_x: 0.25
                     text: _("IPs")
                 PopupButton:  # +
                     id: add_ip
@@ -100,7 +91,7 @@
                     on_release: root.on_ips_remove()
                 PopupButton:  # Edit
                     id: edit_ip
-                    size_hint_x: 0.5
+                    size_hint_x: 0.45
                     text: _("Edit")
                     disabled: True
                     on_release: root.on_ips_edit()

--- a/src/network_puzzles/gui/devices.py
+++ b/src/network_puzzles/gui/devices.py
@@ -127,7 +127,7 @@ class Device(DragBehavior, ThemedBoxLayout):
     def highlight(self, do_highlight=True):
         if do_highlight:
             # Add highlight.
-            # logging.debug(f"GUI: Add highlight for {self.hostname}")
+            # logging.debug(f"Devices: Add highlight for {self.hostname}")
             if not self.highlighting:
                 self.highlighting = HelpHighlight(base=self)
             if self.highlighting not in self.app.root.ids.layout.children:
@@ -136,7 +136,7 @@ class Device(DragBehavior, ThemedBoxLayout):
                 self.app.root.ids.layout.add_widget(self.highlighting, idx)
         else:
             # Remove highlight.
-            # logging.debug(f"GUI: Remove highlight for {self.hostname}")
+            # logging.debug(f"Devices: Remove highlight for {self.hostname}")
             if (
                 self.highlighting
                 and self.highlighting in self.app.root.ids.layout.children
@@ -148,11 +148,11 @@ class Device(DragBehavior, ThemedBoxLayout):
         # Ensure base object state matches GUI object state.
         self.base.is_invisible = do_hide
         if do_hide:
-            logging.debug(f"GUI: Hide {self.hostname} & dependent items.")
+            logging.debug(f"Devices: Hide {self.hostname} & dependent items.")
             # Hide any help highlight.
             self.highlight(False)
         elif do_hide is False:
-            logging.debug(f"GUI: Show {self.hostname} & dependent items.")
+            logging.debug(f"Devices: Show {self.hostname} & dependent items.")
             # Show help highlight if relevant.
             self.app.update_help_highlight_devices()
         # Hide/show any links.
@@ -357,7 +357,7 @@ class EditDevicePopup(ActionPopup):
 
     def on_ips_edit(self):
         if not self.selected_ip:
-            logging.warning("GUI: No IP selected for editing.")
+            logging.warning("Devices: No IP selected for editing.")
             return
         ip_config = self._get_ip_config_from_nic(
             self.device.get_nic(self.selected_nic), self.selected_ip
@@ -413,9 +413,9 @@ class EditDevicePopup(ActionPopup):
         self.ids.nics_list.update_data(self.device.nics, management=True)
 
     def on_okay(self):
-        logging.info(f"GUI: Updating {self.device.hostname}:")
+        logging.info(f"Devices: Updating {self.device.hostname}:")
         for cmd in self.puzzle_commands:
-            logging.info(f"GUI: > {cmd}")
+            logging.info(f"Devices: > {cmd}")
             self.app.ui.parse(cmd)
         # Update GUI helps b/c it will trigger tooltip updates, which are needed
         # b/c IP data has likely changed.
@@ -471,5 +471,5 @@ class EditDevicePopup(ActionPopup):
 
     def _set_ips(self):
         n = self.device.get_nic(self.selected_nic)
-        logging.debug(f"GUI: {n.name} ifaces: {n.interfaces}")
+        logging.debug(f"Devices: {n.name} ifaces: {n.interfaces}")
         self.ids.ips_list.update_data(n.ip_addresses)

--- a/src/network_puzzles/gui/devices.py
+++ b/src/network_puzzles/gui/devices.py
@@ -379,9 +379,9 @@ class EditDevicePopup(ActionPopup):
                 f"set {self.device.hostname} {self.selected_nic} {ip_config.address}/{ip_config.netmask}"
             )
 
-    def on_nic_selection(self, selected_nic):
+    def on_nic_selection(self, selected_nic_text):
         self.selected_ip = None
-        self.selected_nic = selected_nic
+        self.selected_nic = selected_nic_text
         self.root.ids.add_ip.disabled = False
         self.root.ids.edit_ip.disabled = True
         self.root.ids.remove_ip.disabled = True

--- a/src/network_puzzles/gui/labels.kv
+++ b/src/network_puzzles/gui/labels.kv
@@ -12,10 +12,9 @@
     font_size: sp(16)
 
 <CheckBoxLabel>:
-    valign: "center"
-    size_hint_y: None
-    height: app.BUTTON_MAX_H
-    text_size: self.size
+    size_hint_max_y: app.BUTTON_MAX_H
+    size_hint_min_y: self.line_height + self.padding[1] + self.padding[3]
+    text_size: (self.width, self.text_size[1])
 
 <EditDeviceLabel@ThemedLabel>:
     font_size: sp(20)
@@ -37,7 +36,7 @@
         Rectangle:
             pos: self.pos
             size: self.size
-    valign: 'center'
+    valign: "center"
     text_size: self.size
     padding: dp(3)
 

--- a/src/network_puzzles/gui/labels.kv
+++ b/src/network_puzzles/gui/labels.kv
@@ -13,6 +13,8 @@
 
 <CheckBoxLabel>:
     valign: "center"
+    size_hint_y: None
+    height: app.BUTTON_MAX_H
     text_size: self.size
 
 <EditDeviceLabel@ThemedLabel>:

--- a/src/network_puzzles/gui/layouts.kv
+++ b/src/network_puzzles/gui/layouts.kv
@@ -3,7 +3,8 @@
     spacing: dp(3)
 
 <SingleRowLayout>:
-    size_hint_max_y: app.BUTTON_MAX_H + dp(8)
+    size_hint_y: None
+    height: app.BUTTON_MAX_H
     padding: (dp(1), dp(1), dp(1), dp(1))
     spacing: dp(2)
 

--- a/src/network_puzzles/gui/layouts.py
+++ b/src/network_puzzles/gui/layouts.py
@@ -165,10 +165,10 @@ class PuzzleLayout(RelativeLayout):
                     if len(touch.grab_list) == 0:
                         self.app.chosen_pos = self.to_widget(*touch.pos)
                     return True
-                else:
-                    # NOTE: The touch has to be explicitly passed on so that other
-                    # child widgets (e.g. Links) are notified.
-                    return super().on_touch_up(touch)
+                # NOTE: The touch has to be explicitly passed on so that child
+                # widgets can receive it; e.g. so that Device buttons are able
+                # to be "pressed".
+                return super().on_touch_up(touch)
 
     def _get_infra_devices_choices(self):
         choices = []

--- a/src/network_puzzles/gui/layouts.py
+++ b/src/network_puzzles/gui/layouts.py
@@ -1,6 +1,3 @@
-import logging
-
-from kivy.core.window import Window
 from kivy.metrics import dp, sp
 from kivy.properties import NumericProperty, StringProperty
 from kivy.uix.behaviors import FocusBehavior

--- a/src/network_puzzles/gui/layouts.py
+++ b/src/network_puzzles/gui/layouts.py
@@ -157,20 +157,6 @@ class PuzzleLayout(RelativeLayout):
         ):
             tray.close()
 
-    def get_height(self):
-        # Window height minus terminal area height.
-        h = (
-            Window.height
-            - self.parent.padding[1]
-            - self.parent.padding[3]
-            - (
-                self.terminal_lines * self.terminal_line_height
-            )  # expicitly calculated to equal terminal height
-            - self.parent.spacing
-        )
-        logging.debug(f"GUI: PuzzleLayout height: {h}")
-        return h
-
     def on_touch_up(self, touch):
         if self.collide_point(*touch.pos):
             if touch.button == "left" or touch.button is None:

--- a/src/network_puzzles/gui/networkpuzzles.kv
+++ b/src/network_puzzles/gui/networkpuzzles.kv
@@ -98,11 +98,6 @@ ThemedBoxLayout:
             id: terminal
             size_hint_y: None
             height: self.line_height * 7
-        TextInput:
-            text: " ".join([str(i) for i in range(1000)])
-        TextInput:
-            text: " ".join([str(i) for i in range(1000)])
-            readonly: True
 
 <TerminalLabel>:
     background_color: app.theme.bg3

--- a/src/network_puzzles/gui/networkpuzzles.kv
+++ b/src/network_puzzles/gui/networkpuzzles.kv
@@ -109,3 +109,6 @@ ThemedBoxLayout:
     text_size: self.size
     readonly: True
     do_wrap: False
+    # Override readonly-dependent attribs:
+    keyboard_mode: "managed"  # block automatic on-screen keyboard
+    is_focusable: True  # allow scrolling

--- a/src/network_puzzles/gui/networkpuzzles.kv
+++ b/src/network_puzzles/gui/networkpuzzles.kv
@@ -94,8 +94,6 @@ ThemedBoxLayout:
         padding: dp(0)
         PuzzleLayout:
             id: layout
-            size_hint_y: None
-            height: self.get_height()
         TerminalLabel:
             id: terminal
             size_hint_y: None

--- a/src/network_puzzles/gui/networkpuzzles.kv
+++ b/src/network_puzzles/gui/networkpuzzles.kv
@@ -108,4 +108,5 @@ ThemedBoxLayout:
     font_size: sp(12)
     text_size: self.size
     readonly: True
+    is_focusable: True  # attempt to override attrib set by readonly
     do_wrap: False

--- a/src/network_puzzles/gui/networkpuzzles.kv
+++ b/src/network_puzzles/gui/networkpuzzles.kv
@@ -98,6 +98,8 @@ ThemedBoxLayout:
             id: terminal
             size_hint_y: None
             height: self.line_height * 7
+        TextInput:
+            text: " ".join([str(i) for i in range(1000)])
 
 <TerminalLabel>:
     background_color: app.theme.bg3

--- a/src/network_puzzles/gui/networkpuzzles.kv
+++ b/src/network_puzzles/gui/networkpuzzles.kv
@@ -108,5 +108,4 @@ ThemedBoxLayout:
     font_size: sp(12)
     text_size: self.size
     readonly: True
-    is_focusable: True  # attempt to override attrib set by readonly
     do_wrap: False

--- a/src/network_puzzles/gui/networkpuzzles.kv
+++ b/src/network_puzzles/gui/networkpuzzles.kv
@@ -100,6 +100,9 @@ ThemedBoxLayout:
             height: self.line_height * 7
         TextInput:
             text: " ".join([str(i) for i in range(1000)])
+        TextInput:
+            text: " ".join([str(i) for i in range(1000)])
+            readonly: True
 
 <TerminalLabel>:
     background_color: app.theme.bg3

--- a/src/network_puzzles/gui/networkpuzzles.kv
+++ b/src/network_puzzles/gui/networkpuzzles.kv
@@ -1,4 +1,4 @@
-#:kivy 2.0
+#:kivy 2.1
 #:import _ network_puzzles._
 #:import session network_puzzles.session
 # Order of "include" directives seems to matter.

--- a/src/network_puzzles/gui/packets.py
+++ b/src/network_puzzles/gui/packets.py
@@ -1,6 +1,7 @@
 import logging
-from kivy.uix.widget import Widget
+
 from kivy.properties import NumericProperty
+from kivy.uix.widget import Widget
 
 
 class PacketManager:
@@ -61,7 +62,7 @@ class PacketManager:
             # due to a race condition with a redraw? So skipping packet update
             # if the link isn't found seems to work for now.
             if not link:
-                logging.warning(f"GUI: link not found: {p.get('packetlocation')}")
+                logging.warning(f"Packets: link not found: {p.get('packetlocation')}")
                 continue
 
             # Search for existing packet in layout.

--- a/src/network_puzzles/gui/popups.kv
+++ b/src/network_puzzles/gui/popups.kv
@@ -13,7 +13,6 @@
             root: root
             id: nics_list
         ActionPopupButtons:
-            size_hint_y: 0.2
             on_cancel: root.on_cancel()
             on_okay: root.on_okay()
 

--- a/src/network_puzzles/gui/popups.kv
+++ b/src/network_puzzles/gui/popups.kv
@@ -138,8 +138,6 @@
             ThemedBoxLayout:
                 orientation: 'vertical'
                 CheckBoxLabel:
-                    size_hint_y: None
-                    height: self.texture_size[1]
                     text: _("Filter the puzzles by level:")
                 SingleRowLayout:
                     FiltersCheckBox:

--- a/src/network_puzzles/gui/popups.kv
+++ b/src/network_puzzles/gui/popups.kv
@@ -101,7 +101,7 @@
         HSeparator:
         PopupButton:
             pos_hint: {"center_x": 0.5}
-            size_hint: (None, 0.2)
+            size_hint_x: 0.2
             text: _("Quit")
             on_release: app.stop()
 

--- a/src/network_puzzles/gui/popups.kv
+++ b/src/network_puzzles/gui/popups.kv
@@ -141,40 +141,40 @@
                     text: _("Filter the puzzles by level:")
                 SingleRowLayout:
                     FiltersCheckBox:
-                        name: 'Level0'
+                        name: "Level0"
                     CheckBoxLabel:
                         text: _("Level 0")
                 SingleRowLayout:
                     FiltersCheckBox:
-                        name: 'Level1'
+                        name: "Level1"
                     CheckBoxLabel:
                         text: _("Level 1")
                 SingleRowLayout:
                     FiltersCheckBox:
-                        name: 'Level2'
+                        name: "Level2"
                     CheckBoxLabel:
                         text: _("Level 2")
                 SingleRowLayout:
                     FiltersCheckBox:
-                        name: 'Level3'
+                        name: "Level3"
                     CheckBoxLabel:
                         text: _("Level 3")
                 SingleRowLayout:
                     FiltersCheckBox:
-                        name: 'Level4'
+                        name: "Level4"
                     CheckBoxLabel:
                         text: _("Level 4")
                 SingleRowLayout:
                     FiltersCheckBox:
-                        name: 'Level5'
+                        name: "Level5"
                     CheckBoxLabel:
                         text: _("Level 5")
                 SingleRowLayout:
                     FiltersCheckBox:
-                        name: 'Level6'
+                        name: "Level6"
                     CheckBoxLabel:
                         text: _("Level 6")
-                Widget:
+                Widget: # spacer to keep other widgets at the top
             VSeparator:
             PuzzlesRecView:
                 id: puzzles_view

--- a/src/network_puzzles/gui/popups.py
+++ b/src/network_puzzles/gui/popups.py
@@ -78,7 +78,7 @@ class EditDhcpPopup(ActionPopup):
                 end = row.children[-3].text
                 if start != c.get("mask") or end != c.get("gateway"):
                     cmd = f"set {self.device.hostname} dhcp {ip} {start}-{end}"
-                    logging.info(f"GUI: > {cmd}")
+                    logging.info(f"Popups: > {cmd}")
                     self.app.ui.parse(cmd)
 
         # Update GUI helps b/c it will trigger tooltip updates, which are needed

--- a/src/network_puzzles/gui/popups.py
+++ b/src/network_puzzles/gui/popups.py
@@ -39,8 +39,9 @@ class ChooseNicPopup(ActionPopup):
         ]
         self.ids.nics_list.update_data(free_nics, management=False)
 
-    def on_nic_selection(self, selected_nic):
-        self.selected_nic = selected_nic
+    def on_nic_selection(self, selected_nic_text):
+        # Strip MAC info from NIC text.
+        self.selected_nic = selected_nic_text.split(";")[0]
 
     def on_okay(self):
         self.app.chosen_nic = self.selected_nic

--- a/src/network_puzzles/ui.py
+++ b/src/network_puzzles/ui.py
@@ -6,6 +6,7 @@ from . import packet, parser, puzzle, session
 
 class UI:
     TITLE = "NetworkPuzzles"
+    PS1 = "->"
 
     def __init__(self):
         self.parser = parser.Parser()
@@ -160,7 +161,7 @@ class CLI(UI):
     def prompt(self):
         """A CLI only function.  Prompt for imput and process it"""
         try:
-            answer = input("-> ")
+            answer = input(f"{self.PS1} ")
             self.parser.parse(answer, True)
             # if we created packets, process them until done.
             count = 0

--- a/src/network_puzzles/vars.py
+++ b/src/network_puzzles/vars.py
@@ -26,25 +26,14 @@ class Session:
         self.ui = None
         self.startinglevel = ""
         self.package_dir = Path(__file__).parent
-        self.device_type = self.get_device_type()
 
-    def print(self, message):
-        print("<default print method>")
-        print(message)
+    @property
+    def device_type(self) -> str:
+        """Returns device type: 'desktop' or 'mobile'.
 
-    def add_undo_entry(self, forwards_cmd: str, backwards_cmd: str, payload=None):
-        """Add a record to the undo list.
-        The forwards command is used for redo,
-        the backwards command is used for undo.
-        the payload is used if we delete something and need to recover it."""
-        newrec = {}
-        newrec["forwards"] = forwards_cmd
-        newrec["backwards"] = backwards_cmd
-        newrec["payload"] = payload
-        self.undolist.append(newrec)
-
-    def get_device_type(self) -> str:
-        """Returns device type: 'desktop' or 'mobile'."""
+        Generally, the app will assume a touch interface on mobile devices and a
+        mouse interface on desktop devices.
+        """
         if hasattr(sys, "getandroidapilevel"):
             # Android
             return "mobile"
@@ -60,3 +49,18 @@ class Session:
         else:
             # Fallback
             return "mobile"
+
+    def print(self, message):
+        print("<default print method>")
+        print(message)
+
+    def add_undo_entry(self, forwards_cmd: str, backwards_cmd: str, payload=None):
+        """Add a record to the undo list.
+        The forwards command is used for redo,
+        the backwards command is used for undo.
+        the payload is used if we delete something and need to recover it."""
+        newrec = {}
+        newrec["forwards"] = forwards_cmd
+        newrec["backwards"] = backwards_cmd
+        newrec["payload"] = payload
+        self.undolist.append(newrec)

--- a/src/network_puzzles/vars.py
+++ b/src/network_puzzles/vars.py
@@ -34,7 +34,16 @@ class Session:
         Generally, the app will assume a touch interface on mobile devices and a
         mouse interface on desktop devices.
         """
-        if hasattr(sys, "getandroidapilevel"):
+        default = "mobile"
+
+        if os.getenv("NETWORKPUZZLES_DEVICE_TYPE"):
+            # Dev override
+            value = os.getenv("NETWORKPUZZLES_DEVICE_TYPE").lower()
+            if value in ("desktop", "mobile"):
+                return value
+            else:
+                return default
+        elif hasattr(sys, "getandroidapilevel"):
             # Android
             return "mobile"
         elif os.getenv("DISPLAY"):
@@ -48,7 +57,7 @@ class Session:
             return "mobile"
         else:
             # Fallback
-            return "mobile"
+            return default
 
     def print(self, message):
         print("<default print method>")


### PR DESCRIPTION
- Add module name to debug log lines for easier troubleshooting
- Standardize several GUI elements for better extensibility
- Fix issue where puzzle elements were sometimes erroneously laid out in portrait orientation
- Make "Terminal" scrollable on mobile
- Add "PS1" value (i.e. "->") to terminal lines output
- Deselect Terminal text when tapping/clicking outside if Terminal area
- Various linting fixes